### PR TITLE
Bug fix - virtual scroller will render items that aren't visible.

### DIFF
--- a/src/Virtualizer/VirtualManager.ts
+++ b/src/Virtualizer/VirtualManager.ts
@@ -417,7 +417,7 @@ export default class VirtualManager<T> {
         // console.log({ existingKeys, renderKeys, newKeys })
 
         // we do a deep compare as we don't want to cause react re-rendering unless our rendered item renderKeys have changed.
-        if (oldKeys.length !== newKeys.length || JSON.stringify(oldKeys) !== JSON.stringify(newKeys) {
+        if (oldKeys.length !== newKeys.length || JSON.stringify(oldKeys) !== JSON.stringify(newKeys)) {
             // const debug = true;
             // if (debug) {
             //     let counts: any = {};

--- a/src/Virtualizer/VirtualManager.ts
+++ b/src/Virtualizer/VirtualManager.ts
@@ -403,12 +403,10 @@ export default class VirtualManager<T> {
             getType
         );
         const elementLookup = this.getElementLookupByKey();
-        let hasDeletedKeys = false;
         newKeys.forEach(key => {
             let element = elementLookup.get(key);
             if (element) {
                 const deleted = !existingKeys.has(key);
-                hasDeletedKeys = hasDeletedKeys || deleted;
                 //  we HAVE to use display: none
                 //  if we use visibility: hidden then the hidden elements
                 //  still count for scroll size
@@ -419,9 +417,7 @@ export default class VirtualManager<T> {
         // console.log({ existingKeys, renderKeys, newKeys })
 
         // we do a deep compare as we don't want to cause react re-rendering unless our rendered item renderKeys have changed.
-        // Since both oldKeys and newKeys came from sets, we can assume there are no duplicates. This means that if the arrays
-        // are the same length, and no keys that are in newKeys are missing from oldKeys, then the arrays must be the same!
-        if (oldKeys.length !== newKeys.length || hasDeletedKeys) {
+        if (oldKeys.length !== newKeys.length || JSON.stringify(oldKeys) !== JSON.stringify(newKeys) {
             // const debug = true;
             // if (debug) {
             //     let counts: any = {};

--- a/src/Virtualizer/VirtualManager.ts
+++ b/src/Virtualizer/VirtualManager.ts
@@ -6,7 +6,7 @@ NOTICE: Adobe permits you to use, modify, and distribute this file in
 accordance with the terms of the Adobe license agreement accompanying
 it. If you have received this file from a source other than Adobe,
 then your use, modification, or distribution of it requires the prior
-written permission of Adobe. 
+written permission of Adobe.
 */
 import "../common/ResizeObserver";
 import ResizeObserver, { ResizeObserverEntry, UxpResizeObserver } from '../common/ResizeObserver';
@@ -82,7 +82,7 @@ export default class VirtualManager<T> {
     private containerPadding: Margin = new Margin(0)
     private placeholder: HTMLDivElement
     private containerWidth: number;
-    
+
     constructor(props: ContainerProperties<T>) {
         this.container = props.container;
         this.containerWidth = this.container.clientWidth;
@@ -91,7 +91,7 @@ export default class VirtualManager<T> {
         this.itemKey = props.itemKey;
         this.itemType = props.itemType;
         this.itemRect = props.itemRect;
-        this.onresize = this.onresize.bind(this);      
+        this.onresize = this.onresize.bind(this);
         this.resizeObserver = new ResizeObserver(this.onresize);
         this.updateAndLayout = this.updateAndLayout.bind(this);
         this.container.addEventListener("scroll", (e) => {
@@ -121,7 +121,7 @@ export default class VirtualManager<T> {
                 checkForDuplicates.add(key);
                 this.itemLookup.set(key, item);
             }
-    
+
             this.updateIndexes(true);
             this.layoutChildren();
         }
@@ -217,7 +217,7 @@ export default class VirtualManager<T> {
             }
 
             let type = this.itemType(item)!;
-            let properties = this.getItemProperties(key, type);            
+            let properties = this.getItemProperties(key, type);
             let classProps = this.classProperties.get(type);
             if (!classProps) {
                 console.warn("missing class properties: " + type);
@@ -297,43 +297,6 @@ export default class VirtualManager<T> {
         }
     }
 
-    /**
-     * Returns the index of the first and last visible items in the current scroll window.
-     */
-    private getFirstAndLastVisibleItemIndex(
-        visibleTop = this.container.scrollTop,
-        visibleBottom = visibleTop + this.container.clientHeight
-    ) {
-        let first: number | undefined
-        let last: number | undefined
-        for (let index = 0; index < this.items.length; index++) {
-            let item = this.items[index];
-            let rect = this.getItemRect(item);
-            if (rect == null) {
-                break;
-            }
-            if (first == null && (rect.y + rect.height) > visibleTop) {
-                first = index;
-            }
-            if (rect.y <= visibleBottom) {
-                if (first != null) {
-                    last = index;
-                }
-            }
-            else {
-                break;
-            }
-        }
-        if (first == null) {
-            first = 0;
-        }
-        if (last == null) {
-            //  if nothings rendered yet this is a guess
-            last = Math.min(this.items.length - 1, first + initialVisibleItemCount);
-        }
-        return [first, last];
-    }
-
     get pageSize() {
         return this.container.clientHeight;
     }
@@ -346,9 +309,9 @@ export default class VirtualManager<T> {
         return 500;
     }
 
-    private getFirstAndLastRenderItemIndex(scrollDirection: number) {
+    private getRenderItemIndices(scrollDirection: number) {
         let top = Math.max(0, this.container.scrollTop);
-        let { pageSize, prerenderScrollDirection, prerenderOtherDirection } = this;
+        const { pageSize, prerenderScrollDirection, prerenderOtherDirection } = this;
         if (scrollDirection === 0) {
             // if we aren't scrolling then each direction is other.
             prerenderScrollDirection = prerenderOtherDirection;
@@ -360,18 +323,28 @@ export default class VirtualManager<T> {
         // then expand bottom by whatever is remaining. (if this is larger than content area, that is fine)
         bottom = top + totalPagesHeight;
 
-        let firstAndLast = this.getFirstAndLastVisibleItemIndex(top, bottom);
+        const renderKeys = new Set<string>();
+        const existingKeys = new Set<string>();
 
-        // console.log(JSON.stringify({
-        //     scroll: scrollDirection,
-        //     t: this.container.scrollTop,
-        //     b: this.container.scrollTop + pageSize,
-        //     pageSize,
-        //     page: pageSize, top, bottom,
-        //     firstAndLast,
-        //     placeholderHeight: this.placeholder.style.height
-        // }));
-        return firstAndLast;
+        for (let index = 0; index < this.items.length; index++) {
+            const item = this.items[index];
+            const key = this.itemKey(item);
+
+            existingKeys.add(key);
+
+            const rect = this.getItemRect(item);
+            if (rect && ((rect.y + rect.height) > visibleTop) && (rect.y <= visibleBottom)) {
+                renderKeys.add(key);
+            }
+        }
+
+        // we also want to always keep rendering a focused item so add this too
+        const focusedKey = this.getFocusedItemKey();
+        if (focusedKey) {
+            renderKeys.add(focusedKey);
+        }
+
+        return [ renderKeys, existingKeys ];
     }
 
     private getFocusedItemKey() {
@@ -397,7 +370,7 @@ export default class VirtualManager<T> {
         const scrollTop = this.container.scrollTop;
         const scrollDelta = scrollTop - this.lastScrollTop;
         this.lastScrollTop = scrollTop;
-        
+
         const previousItems = this.previousItems || this.items;
         this.previousItems = this.items;
         const itemsProbablyChanged = this.items.length !== previousItems.length;
@@ -408,22 +381,9 @@ export default class VirtualManager<T> {
             this.scrollDirection = Math.sign(scrollDelta);
         }
 
-        const [firstRender, lastRender] = this.getFirstAndLastRenderItemIndex(this.scrollDirection);
-
-        const renderKeys = new Set<string>();
-        for (let i = firstRender; i <= lastRender; i++) {
-            renderKeys.add(this.itemKey(this.items[i]));
-        }
-        // we also want to always keep rendering a focused item so check
-        const focusedKey = this.getFocusedItemKey();
-        if (focusedKey) {
-            renderKeys.add(focusedKey);
-        }
-
-        const existingKeys = new Set<string>();
-        for (let item of this.items) {
-            existingKeys.add(this.itemKey(item));
-        }
+        // Get a set of the items we want to render, and a set of all the items
+        // (do this in one method, so we only need to iterate through all the items once)
+        const [ renderKeys, existingKeys ] = this.getRenderItemIndices(this.scrollDirection);
 
         const getType = (key: string) => {
             if (key != null) {
@@ -454,10 +414,11 @@ export default class VirtualManager<T> {
             }
         });
 
-        // console.log({ existingKeys, renderKeys, newKeys, firstRender, lastRender })
+        // console.log({ existingKeys, renderKeys, newKeys })
 
         // we do a deep compare as we don't want to cause react re-rendering unless our rendered item renderKeys have changed.
-        if (JSON.stringify(oldKeys) !== JSON.stringify(newKeys)) {
+        // (optimization - we can skip the deep compare if the set sizes are different, since that means they're definitely different)
+        if (oldKeys.size !== newKeys.size || JSON.stringify(oldKeys) !== JSON.stringify(newKeys)) {
             // const debug = true;
             // if (debug) {
             //     let counts: any = {};

--- a/src/test/ContainerTest.ts
+++ b/src/test/ContainerTest.ts
@@ -6,16 +6,21 @@ NOTICE: Adobe permits you to use, modify, and distribute this file in
 accordance with the terms of the Adobe license agreement accompanying
 it. If you have received this file from a source other than Adobe,
 then your use, modification, or distribution of it requires the prior
-written permission of Adobe. 
+written permission of Adobe.
 */
 import path from "path";
 import { after, before, describe, it } from "mocha";
 import { strict as assert } from "assert";
 import { JSDOM } from "jsdom";
-import SampleContainer from "./SampleContainer";
+import { getSampleItems, getSampleContainer } from "./SampleContainer";
 
 const testHtml = path.join(__dirname, "../../src/test/test.html");
 declare const global: NodeJS.Global & any;
+
+const containerHeight = 400;
+const backwardPrerender = 100;
+const forwardPrerender = 500;
+const itemHeight = 50;
 
 describe('Container', function() {
     let dom: JSDOM;
@@ -43,8 +48,6 @@ describe('Container', function() {
             // dom.window.document.body.clientHeight = 800;
             let target = document.getElementById("app");
             // we have to stub clientHeight on the target or Virtualizer won't render
-            const containerHeight = 400;
-            const itemHeight = 50;
             Object.defineProperties(dom.window.HTMLElement.prototype, {
                 clientHeight: {
                     get() {
@@ -55,7 +58,7 @@ describe('Container', function() {
             if (target == null) {
                 throw new Error("Element doesn't exist");
             }
-            ReactDOM.render(SampleContainer, target);
+            ReactDOM.render(getSampleContainer(getSampleItems()), target);
             let container = target.firstElementChild as HTMLDivElement;
             // simulate stuff.
             let placeholderCount = 1;
@@ -121,6 +124,37 @@ describe('Container', function() {
             //  this shows that we are recycling elements.
             const lastTotal = counts.slice(-10).reduce((a, b) => a + b, 0);
             assert(lastTotal / 10 === counts[counts.length - 1]);
+        });
+
+        it("should not render items that are not visible", async () => {
+            const target = document.getElementById("app");
+
+            // Make the first item really big - we want to make sure it's rendered if partially visible, but
+            // other items that are completely off-screen are not rendered.
+            const items = getSampleItems();
+            items[0].rect.height = 10000;
+
+            ReactDOM.render(getSampleContainer(items), target);
+            const container = target.firstElementChild as HTMLDivElement;
+
+            // Scroll so the first item is still visible, but many items on the way are not visible
+            const scrollTop = 7000;
+            container.scrollTop = scrollTop;
+            container.dispatchEvent(new dom.window.CustomEvent('scroll'));
+
+            // Only visible elements should be rendered (including the prerender windows)
+            const topVisible = scrollTop - backwardPrerender;
+            const bottomVisible = scrollTop + containerHeight + forwardPrerender;
+            function checkVisible(element: HTMLElement) {
+                const top = parseInt(element.style.top);
+                const height = parseInt(element.style.height);
+                // Note: There's a window of the container height above/below the viewable region that we still render
+                assert(top <= bottomVisible && top + height >= topVisible);
+            }
+
+            const children = Array.from(container.children).slice(1) as HTMLElement[];
+            children.forEach(checkVisible);
+            assert(children.length === 22);
         });
     });
 

--- a/src/test/SampleContainer.tsx
+++ b/src/test/SampleContainer.tsx
@@ -6,7 +6,7 @@ NOTICE: Adobe permits you to use, modify, and distribute this file in
 accordance with the terms of the Adobe license agreement accompanying
 it. If you have received this file from a source other than Adobe,
 then your use, modification, or distribution of it requires the prior
-written permission of Adobe. 
+written permission of Adobe.
 */
 import { getItems, Record } from "./sampleLines";
 import React, { useState, useRef } from "react";
@@ -24,27 +24,32 @@ function Row(properties: { children: string, [other: string]: any }) {
     );
 }
 
-let items: any[] = [];
-let itemsPerSection = 20;
-for (let section = 0; section < 100; section++) {
-    // for (let i = 0; i < 300; i++) {
-        items.push({ key: String(- section - 1), type: "row", row: `Section Header: ${section}`})
-    // }
-    for (let i = 0; i < itemsPerSection; i++) {
-        items.push(getItems(section * itemsPerSection + i));
-    };
-}
-//  now add absolute position rects to all items to simulate external cc-library style positioning.
-//  also because jsdom doesn't actually perform any layout.
-for (let i = 0; i < items.length; i++) {
-    const height = 50;
-    items[i].rect = { x: 0, y: i * height, width: 800, height };
+export function getSampleItems() {
+    let items: any[] = [];
+    let itemsPerSection = 20;
+    for (let section = 0; section < 100; section++) {
+        // for (let i = 0; i < 300; i++) {
+            items.push({ key: String(- section - 1), type: "row", row: `Section Header: ${section}`})
+        // }
+        for (let i = 0; i < itemsPerSection; i++) {
+            items.push(getItems(section * itemsPerSection + i));
+        };
+    }
+    //  now add absolute position rects to all items to simulate external cc-library style positioning.
+    //  also because jsdom doesn't actually perform any layout.
+    for (let i = 0; i < items.length; i++) {
+        const height = 50;
+        items[i].rect = { x: 0, y: i * height, width: 800, height };
+    }
+    return items;
 }
 
-export default <Container items={items} itemKey="key" itemType="type" itemRect="rect" className="SampleContainer">
-    {
-        item => item.row
-            ? <Row>{item.row}</Row>
-            : <img className="SampleCell" src={item.images[0]} title={item.text}></img>
-    }
-</Container>;
+export function getSampleContainer(items) {
+    return <Container items={items} itemKey="key" itemType="type" itemRect="rect" className="SampleContainer">
+        {
+            item => item.row
+                ? <Row>{item.row}</Row>
+                : <img className="SampleCell" src={item.images[0]} title={item.text}></img>
+        }
+    </Container>;
+}


### PR DESCRIPTION
If you have an item that has a large height, then there's a bug where the virtual scroller will render all the items that overlap the tall item, if the tall item is visible. This means that many items that aren't visible are being rendered.

Worst case is you have an item that groups all the other items - this effectively turns off virtualization making it really slow to render.

In the code, it's finding the first and last visible items and assuming all items between these are also visible - which is an incorrect assumption. Fix is to just check each individual item is visible.

The fix is no slower than the original code, since it iterates through all the items anyway, to compute the existingKeys set - we can just combine these in a single iteration, which is fast, but allows us to check the visibility of each item separately.