### PR TITLE
Add scrollBy API

### DIFF
--- a/src/Virtualizer/Virtualizer.tsx
+++ b/src/Virtualizer/Virtualizer.tsx
@@ -65,6 +65,18 @@ export default forwardRef(function Virtualizer<T>(properties: VirtualizerPropert
     for (let item of items) {
         keyToItem.set(itemKeyFunction(item), item);
     }
+    function scrollByFunction(offset: number) {
+        const container = cache.current!.container;
+        if (container && offset) {
+            // Would be cleaner to use container.scrollBy, but UXP doesn't support this
+            // Instead, we need to compute the scrollTop to set based on the passed in offset
+            const clientHeight = container.clientHeight;
+            const scrollHeight = container.scrollHeight;
+            const maxScrollTop = Math.max(0, scrollHeight - clientHeight);
+            const scrollTop = Math.max(0, Math.min(maxScrollTop, container.scrollTop + offset));
+            container.scrollTo({ top: scrollTop });
+        }
+    }
     function scrollToItemFunction(key: string) {
         let container = cache.current!.container
         if (container) {
@@ -81,7 +93,10 @@ export default forwardRef(function Virtualizer<T>(properties: VirtualizerPropert
             }
         }
     }
-    useImperativeHandle(ref, () => ({ scrollToItem: scrollToItemFunction }));
+    useImperativeHandle(ref, () => ({
+        scrollToItem: scrollToItemFunction,
+        scrollBy: scrollByFunction
+    }));
     function setContainer(container) {
         if (container) {
             if (ref) {

--- a/src/Virtualizer/Virtualizer.tsx
+++ b/src/Virtualizer/Virtualizer.tsx
@@ -65,15 +65,16 @@ export default forwardRef(function Virtualizer<T>(properties: VirtualizerPropert
     for (let item of items) {
         keyToItem.set(itemKeyFunction(item), item);
     }
-    function scrollByFunction(offset: number) {
+    function scrollByFunction(x: number, y: number) {
         const container = cache.current!.container;
-        if (container && offset) {
+        // x is ignored, since we only scroll vertically
+        if (container && y) {
             // Would be cleaner to use container.scrollBy, but UXP doesn't support this
             // Instead, we need to compute the scrollTop to set based on the passed in offset
             const clientHeight = container.clientHeight;
             const scrollHeight = container.scrollHeight;
             const maxScrollTop = Math.max(0, scrollHeight - clientHeight);
-            const scrollTop = Math.max(0, Math.min(maxScrollTop, container.scrollTop + offset));
+            const scrollTop = Math.max(0, Math.min(maxScrollTop, container.scrollTop + y));
             container.scrollTo({ top: scrollTop });
         }
     }

--- a/src/test/ContainerTest.ts
+++ b/src/test/ContainerTest.ts
@@ -156,6 +156,34 @@ describe('Container', function() {
             children.forEach(checkVisible);
             assert(children.length === 22);
         });
+
+        it("should support scrollBy", async () => {
+            const target = document.getElementById("app")!;
+
+            let scrollerAPI;
+            const items = getSampleItems();
+            ReactDOM.render(getSampleContainer(items, api => scrollerAPI = api), target);
+            const container = target.firstElementChild as HTMLDivElement;
+            container.scrollTop = 0;
+
+            // JSDOM doesn't set scrollHeight, so we have to fake it:
+            Object.defineProperty(container, 'scrollHeight', { get: () => 1000 });
+
+            // JSDOM doesn't implement scrollTo, so we have to fake it:
+            container.scrollTo = (options?) => container.scrollTop = options.top;
+
+            scrollerAPI.scrollBy(100);
+            assert(container.scrollTop === 100);
+
+            scrollerAPI.scrollBy(-50);
+            assert(container.scrollTop === 50);
+
+            scrollerAPI.scrollBy(-100);
+            assert(container.scrollTop === 0);
+
+            scrollerAPI.scrollBy(1000);
+            assert(container.scrollTop === 600); // Max is scrollHeight - clientHeight
+        });
     });
 
     after(() => {

--- a/src/test/ContainerTest.ts
+++ b/src/test/ContainerTest.ts
@@ -172,16 +172,16 @@ describe('Container', function() {
             // JSDOM doesn't implement scrollTo, so we have to fake it:
             container.scrollTo = (options?) => container.scrollTop = options.top;
 
-            scrollerAPI.scrollBy(100);
+            scrollerAPI.scrollBy(0, 100);
             assert(container.scrollTop === 100);
 
-            scrollerAPI.scrollBy(-50);
+            scrollerAPI.scrollBy(0, -50);
             assert(container.scrollTop === 50);
 
-            scrollerAPI.scrollBy(-100);
+            scrollerAPI.scrollBy(0, -100);
             assert(container.scrollTop === 0);
 
-            scrollerAPI.scrollBy(1000);
+            scrollerAPI.scrollBy(0, 1000);
             assert(container.scrollTop === 600); // Max is scrollHeight - clientHeight
         });
     });

--- a/src/test/SampleContainer.tsx
+++ b/src/test/SampleContainer.tsx
@@ -44,8 +44,8 @@ export function getSampleItems() {
     return items;
 }
 
-export function getSampleContainer(items) {
-    return <Container items={items} itemKey="key" itemType="type" itemRect="rect" className="SampleContainer">
+export function getSampleContainer(items, getAPI?) {
+    return <Container items={items} itemKey="key" itemType="type" itemRect="rect" className="SampleContainer" ref={ getAPI }>
         {
             item => item.row
                 ? <Row>{item.row}</Row>


### PR DESCRIPTION
Support a scrollBy method, so we can adjust the scroll position by a positive or negative offset.

This is to support simulating auto-scrolling, which UXP doesn't yet support.