### PR TITLE
Fix bugs with scrollTop

### DIFF
--- a/src/Virtualizer/VirtualManager.ts
+++ b/src/Virtualizer/VirtualManager.ts
@@ -462,7 +462,14 @@ export default class VirtualManager<T> {
             return;
         }
 
-        const scrollTop = this.container.scrollTop;
+        // Clip scrollTop - UXP should do this automatically, but it doesn't due to bug UXP-10612
+        // Can remove this once UXP bug is fixed
+        const scrollHeight = this.container.scrollHeight;
+        const scrollTop = Math.max(0, Math.min(this.container.scrollTop, scrollHeight - this.container.clientHeight));
+        if (this.container.scrollTop !== scrollTop) {
+            this.container.scrollTop = scrollTop;
+        }
+
         const scrollDelta = scrollTop - this.lastScrollTop;
         this.lastScrollTop = scrollTop;
 
@@ -608,11 +615,7 @@ export default class VirtualManager<T> {
             if (bounds) {
                 const manualLayout = this.isManualLayout;
                 const clientHeight = container.clientHeight;
-                const scrollHeight = container.scrollHeight;
-                const targetScrollTop = Math.min(
-                    bounds.y - itemPin * bounds.height + windowPin * clientHeight,
-                    Math.max(0, scrollHeight + clientHeight)
-                );
+                const targetScrollTop = bounds.y - itemPin * bounds.height + windowPin * clientHeight;
                 if (manualLayout) {
                     container.scrollTo({ top: targetScrollTop, behavior: "smooth" });
                 }

--- a/src/test/ContainerTest.ts
+++ b/src/test/ContainerTest.ts
@@ -47,11 +47,16 @@ describe('Container', function() {
         it("should render initial items and respond to scrolling", async () => {
             // dom.window.document.body.clientHeight = 800;
             let target = document.getElementById("app");
-            // we have to stub clientHeight on the target or Virtualizer won't render
+            // we have to stub clientHeight/scrollHeight on the target or Virtualizer won't render
             Object.defineProperties(dom.window.HTMLElement.prototype, {
                 clientHeight: {
                     get() {
                         return this.parentElement === target ? containerHeight : itemHeight;
+                    }
+                },
+                scrollHeight: {
+                    get() {
+                        return 10000;
                     }
                 }
             })


### PR DESCRIPTION
@krisnye Two bug fixes:

1) There's a UXP bug where scrollTop doesn't get updated properly when scrollHeight is reduced (UXP-10612) - this still hasn't been fixed in the last year, so we need a workaround to detect this.

2) There's a bug with scrollToItem - it uses the scrollHeight in its computation as a clip, but scrollHeight hasn't updated yet if you're switching to a different view of items as part of revealing something. This means it clips to the previous scrollHeight so doesn't actually scroll to the item.

For (2) I removed the clip so this works, but not sure if there's a better fix (e.g. don't rely on scrollHeight to get the total height)