### PR TITLE
fix(VirtualManager): update layout after implicit scrollTo

### DIFF
--- a/src/Virtualizer/VirtualManager.ts
+++ b/src/Virtualizer/VirtualManager.ts
@@ -822,6 +822,7 @@ export default class VirtualManager<T extends object> {
         const top = this.getItemTargetScrollPosition(scrollAnchor);
         if (top != null) {
             this.startScrollAnimation(scrollAnchor);
+            this.updateAndLayout(false);
         }
     }
 


### PR DESCRIPTION
ENG: without this update it can happen that the host updates the view without emitting a scroll event (on jump scrolling), resulting in a half rendered virtual view